### PR TITLE
fix index of first bid that does not result in a win

### DIFF
--- a/exercises/e1.md
+++ b/exercises/e1.md
@@ -64,13 +64,15 @@ Thus, third-price auction is not DSIC.
 The analogue of a second-price auction for multiple identical units of a good has the following mechanism:
 1. Collect bids $b_1 > b_2 > ... > b_n$ (strict inequality to avoid ties);
 2. Players with $k$ highest bids receive one good each;
-3. All winners pay $b_{k-1}$.
+3. All winners pay $b_{k+1}$.
 
 Let's assume player $m$ truthfully declares their bid $b_m = v_m$, others bid arbitrarily.
-* If $m$ wins in this scenario (i.e., $v_m > b_k$), they have no incentive to deviate: bidding more simply doesn't change the outcome, bidding less can lead to losing an auction (if $b_m^\prime < b_k$) or not changing the outcome at all (if $b_k < b_m^\prime < b_m$);
-* If $m$ loses in this scenario (i.e., $v_m < b_k$), they also have no incentive to deviate: bidding less doesn't change the situation, bidding more either doesn't change the outcome (if $b_m < b_m^\prime < b_k$), or leads to winning the auction (if $b_m > b_k > v_m$) with negative utility.
+* If $m$ wins in this scenario (i.e., $v_m > b_{k+1}$), they have no incentive to deviate: bidding more simply doesn't change the outcome, bidding less can lead to losing an auction (if $b_m^\prime < b_{k+1}$) or not changing the outcome at all (if $b_{k+1} < b_m^\prime < b_m$);
+* If $m$ loses in this scenario (i.e., $v_m < b_{k+1}$), they also have no incentive to deviate: bidding less doesn't change the situation, bidding more either doesn't change the outcome (if $b_m < b_m^\prime < b_{k+1}$), or leads to winning the auction (if $b_m > b_{k+1} > v_m$) with negative utility.
 
 Thus, this mechanism is DSIC.
+
+Notice that for $k=1$ this mechanism describes the second-price auction.
 
 ### Exercise 7
 

--- a/exercises/e1.md
+++ b/exercises/e1.md
@@ -62,17 +62,22 @@ Thus, third-price auction is not DSIC.
 ### Exercise 6
 
 The analogue of a second-price auction for multiple identical units of a good has the following mechanism:
-1. Collect bids $b_1 > b_2 > ... > b_n$ (strict inequality to avoid ties);
-2. Players with $k$ highest bids receive one good each;
+1. Collect bids and reindex bidders so that bids are in decreasing order: $b_1 > b_2 > ... > b_n$ (strict inequality to avoid ties);
+2. Bidders $\\{1, 2, \dots, k\\}$ win one good each;
 3. All winners pay $b_{k+1}$.
 
-Let's assume player $m$ truthfully declares their bid $b_m = v_m$, others bid arbitrarily.
-* If $m$ wins in this scenario (i.e., $v_m > b_{k+1}$), they have no incentive to deviate: bidding more simply doesn't change the outcome, bidding less can lead to losing an auction (if $b_m^\prime < b_{k+1}$) or not changing the outcome at all (if $b_{k+1} < b_m^\prime < b_m$);
-* If $m$ loses in this scenario (i.e., $v_m < b_{k+1}$), they also have no incentive to deviate: bidding less doesn't change the situation, bidding more either doesn't change the outcome (if $b_m < b_m^\prime < b_{k+1}$), or leads to winning the auction (if $b_m > b_{k+1} > v_m$) with negative utility.
-
-Thus, this mechanism is DSIC.
-
 Notice that for $k=1$ this mechanism describes the second-price auction.
+
+Let's show the mechanism is DSIC.
+Consider an arbitrary bidder $m$ (after reindexing), and assume that their bid $b_m$ is truthful and equals $v_m$.
+
+If $m$ wins a good in this scenario (i.e., $m \le k$), there's no incentive for them to deviate:
+* bidding more simply won't change the outcome for them;
+* bidding less will either not change the outcome if they are still among $k$ highest bidders or make them lose the good otherwise.
+
+If $m$ loses (i.e., $m \ge k+1$ and $v_m \le b_{k+1}$), there's also no incentive to deviate:
+* bidding less won't change the outcome for them;
+* bidding more will either not change the outcome if they are still outside of $k$ highest bidders or make them overpay for the good otherwise (since they will have to pay at least $b_{k+1}$ for the good they value at most $b_{k+1}$).
 
 ### Exercise 7
 


### PR DESCRIPTION
Hey, i think there is a little error in your solution of exercise 2.2 (here in your script e1/7)  in the description of the first not-winning bid.
Maybe i overlooked something, feel free to correct me. With the way you describe it, it seems that player $k$ could get an advantage by bidding less than $v_k$ for example $b_k\prime = b_{k+1}+\epsilon$ where $\epsilon$ is a small number. Player k would still win an item. Before, the utility would have been $0$, but with the new bid $b_k\prime$ the utility would actually be positive. 

But if every winner pay $b_{k+1}$ then i think your arguments hold. So, maybe this is just a typo?